### PR TITLE
[RW-1109] Use stable release for the ocha_ai dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.3",
         "drupal/core": "^10",
-        "unocha/ocha_ai": "^1.7 | dev-RW-1109"
+        "unocha/ocha_ai": "^1.7"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",


### PR DESCRIPTION
Refs: RW-1109