### PR TITLE
[RW-1172] Update ocha_ai and remove dependency on drupal 10 to allow installation on drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "drupal/core": "^10",
-        "unocha/ocha_ai": "dev-RW-1172"
+        "unocha/ocha_ai": "^1.11"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",


### PR DESCRIPTION
Refs: RW-1172