### PR TITLE
[RW-1199] Preserve previous revision log message when updating the entity after classification success or failure.

### DIFF
--- a/src/Enum/ClassificationMessage.php
+++ b/src/Enum/ClassificationMessage.php
@@ -14,4 +14,51 @@ enum ClassificationMessage: string {
   case AttemptsLimitReached = 'Automated classification stopped: too many attempts.';
   case FieldsAlreadySpecified = 'Automated classification skipped: information already provided.';
   case FailedTemporarily = 'Automated classification failed temporarily.';
+
+  /**
+   * Removes all classification messages from a string.
+   *
+   * @param string $input
+   *   The string from which to remove occurrences of classification messages.
+   *
+   * @return string
+   *   The cleaned string with normalized whitespaces.
+   */
+  public static function removeAllClassificationMessages(string $input): string {
+    // Remove all classification messages.
+    foreach (self::cases() as $case) {
+      $input = str_replace($case->value, '', $input);
+    }
+
+    // Remove consecutive whitespaces.
+    $input = preg_replace('/\s+/', ' ', $input);
+
+    // Trim leading and trailing whitespaces.
+    return trim($input);
+  }
+
+  /**
+   * Remove previous classification messages from a string and append new one.
+   *
+   * @param string $input
+   *   The string to process.
+   * @param \Drupal\ocha_content_classification\EnumClassificationMessage $message
+   *   The classification message to add.
+   *
+   * @return string
+   *   The resulting string with the message appended.
+   */
+  public static function addClassificationMessage(string $input, self $message): string {
+    // First clean the input string.
+    $cleaned = self::removeAllClassificationMessages($input);
+
+    // If the cleaned string is empty, just return the message.
+    if (empty($cleaned)) {
+      return $message->value;
+    }
+
+    // Otherwise, add the message with a space separator.
+    return $cleaned . ' ' . $message->value;
+  }
+
 }

--- a/src/Plugin/QueueWorker/ClassificationWorkflowQueueWorker.php
+++ b/src/Plugin/QueueWorker/ClassificationWorkflowQueueWorker.php
@@ -393,7 +393,14 @@ class ClassificationWorkflowQueueWorker extends QueueWorkerBase implements Conta
         $entity->setRevisionUserId($user_id);
       }
       $entity->setRevisionCreationTime(time());
-      $entity->setRevisionLogMessage($message->value);
+
+      // Append the message to the previous revision log message, after removing
+      // old classification messages so that revision information not related to
+      // the classification are not lost.
+      $revision_log = $entity->getRevisionLogMessage() ?? '';
+      $revision_log = ClassificationMessage::addClassificationMessage($revision_log, $message);
+
+      $entity->setRevisionLogMessage($revision_log);
     }
     $entity->setNewRevision(TRUE);
     $entity->save();


### PR DESCRIPTION
Refs: RW-1199